### PR TITLE
Issue #5

### DIFF
--- a/events/templates/events/event_list.html
+++ b/events/templates/events/event_list.html
@@ -14,7 +14,7 @@
                     {% if object.start_date == object.end_date %}
                         <time datetime="{{ object.start_date|date:"Y-m-d" }}">{{ object.start_date|date:"n/d" }}</time>
                     {% else %}
-                        {% if object.start_date|date:"m" = object.end_date|date:"m" %}
+                        {% if object.start_date|date:"m" == object.end_date|date:"m" %}
                             <time datetime="{{ object.start_date|date:"Y-m-d" }}">{{ object.start_date|date:"n/d" }}</time> <abbr title="through">-</abbr> <time datetime="{{ object.end_date|date:"Y-m-d" }}">{{ object.end_date|date:"d" }}</time>
                         {% else %}
                             <time datetime="{{ object.start_date|date:"Y-m-d" }}">{{ object.start_date|date:"n/d" }}</time> <abbr title="through">-</abbr> <time datetime="{{ object.end_date|date:"Y-m-d" }}">{{ object.end_date|date:"n/d" }}</time>

--- a/events/urls.py
+++ b/events/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from events.feeds import UpcomingEvents
 from events.views import event_list
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^feed/$', UpcomingEvents(), '', 'events_feed'),
     url(r'^$', event_list, {}, 'events'),
-)
+]

--- a/events/views.py
+++ b/events/views.py
@@ -1,6 +1,5 @@
 from django.http import Http404
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
 from events.models import Event
@@ -12,6 +11,7 @@ def event_list(request):
     if not object_list:
         raise Http404
 
-    return render_to_response('events/event_list.html',
-        {'object_list': object_list},
-        context_instance=RequestContext(request))
+    return render(request,
+                  template_name='events/event_list.html',
+                  context={'object_list': object_list}
+                  )


### PR DESCRIPTION
Changes:
1. `patterns` has been removed in Django 1.10 so I changed its usage in urls.py to `url`. This is backward compatible till Django 1.7
2. `context_instance` argument of `render_to_response` has been removed in Django 1.10. I changed `render_to_response` to `render`. This is backward compatible to Django 1.4 (I think)
3. `event_list.html` template had a line "{% if xxx = xxx %}". That was corrected also.